### PR TITLE
Implement unknown fields in settings register

### DIFF
--- a/libetrv/data_struct.py
+++ b/libetrv/data_struct.py
@@ -2,7 +2,7 @@ import enum
 
 from .properties import eTRVData, eTRVSingleData
 from .fields import eTRVField, TemperatureField, UTCDateTimeField, LocalDateTimeField, EnumField, \
-    HexField, TextField
+    HexField, TextField, BitField
 
 
 class BatteryData(eTRVSingleData):
@@ -24,8 +24,22 @@ class ScheduleMode(enum.Enum):
     VACATION = 3
     HOLD = 5
 
+class ConfigBits(enum.IntEnum):
+    ADAPTABLE_REGULATION = 0
+    VERTICAL_INSTALATION = 2
+    DISPLAY_FLIP = 3
+    SLOW_REGULATION = 4
+    VALVE_INSTALLED = 6
+    LOCK_CONTROL = 7
+
 
 class SettingsData(eTRVData):
+    adaptable_regulation = BitField(name='config_bits', bit_position=ConfigBits.ADAPTABLE_REGULATION)
+    vertical_instalation = BitField(name='config_bits', bit_position=ConfigBits.VERTICAL_INSTALATION)
+    display_flip = BitField(name='config_bits', bit_position=ConfigBits.DISPLAY_FLIP)
+    slow_regulation = BitField(name='config_bits', bit_position=ConfigBits.SLOW_REGULATION)
+    valve_installed = BitField(name='config_bits', bit_position=ConfigBits.VALVE_INSTALLED)
+    lock_control = BitField(name='config_bits', bit_position=ConfigBits.LOCK_CONTROL)
     temperature_min = TemperatureField()
     temperature_max = TemperatureField()
     frost_protection_temperature = TemperatureField()
@@ -37,7 +51,7 @@ class SettingsData(eTRVData):
     class Meta:
         structure = {
             0x2a: """
-                unsigned char unknow1;
+                unsigned char config_bits;
                 unsigned char temperature_min;
                 unsigned char temperature_max;
                 unsigned char frost_protection_temperature;

--- a/libetrv/data_struct.py
+++ b/libetrv/data_struct.py
@@ -26,6 +26,8 @@ class ScheduleMode(enum.Enum):
 
 
 class SettingsData(eTRVData):
+    temperature_min = TemperatureField()
+    temperature_max = TemperatureField()
     frost_protection_temperature = TemperatureField()
     schedule_mode = EnumField(enum_class=ScheduleMode)
     vacation_temperature = TemperatureField()
@@ -35,7 +37,9 @@ class SettingsData(eTRVData):
     class Meta:
         structure = {
             0x2a: """
-                unsigned char unknow1[3];
+                unsigned char unknow1;
+                unsigned char temperature_min;
+                unsigned char temperature_max;
                 unsigned char frost_protection_temperature;
                 unsigned char schedule_mode;
                 unsigned char vacation_temperature; 

--- a/libetrv/data_struct.py
+++ b/libetrv/data_struct.py
@@ -45,7 +45,7 @@ class SettingsData(eTRVData):
                 unsigned char vacation_temperature; 
                 int vacation_from;
                 int vacation_to;
-                unsigned char unknow2[2];
+                unsigned char padding[2];
             """
         }
 

--- a/libetrv/fields/__init__.py
+++ b/libetrv/fields/__init__.py
@@ -3,3 +3,4 @@ from .datetime import UTCDateTimeField, LocalDateTimeField
 from .enum import EnumField
 from .string import HexField, TextField
 from .temperature import TemperatureField
+from .bit import BitField

--- a/libetrv/fields/bit.py
+++ b/libetrv/fields/bit.py
@@ -1,0 +1,24 @@
+from .base import eTRVField
+
+
+class BitField(eTRVField):
+    def __init__(self, *args, bit_position, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.mask = ( 1 << bit_position )
+
+    def from_raw_value(self, raw_value, property):
+        return ( raw_value & self.mask ) == self.mask
+
+    def to_raw_value(self, value, property):
+        if len(property.raw_data) == 1 and self.handler is None:
+            # Take first and only field
+            handler, raw_data = next(iter(property.raw_data.items()))
+            raw_value = getattr(raw_data, self.name)
+        else:
+            raw_data = property.raw_data[self.handler]
+            raw_value = getattr(raw_data, self.name)
+        
+        raw_value_new = (raw_value & (~self.mask))
+        if value:
+            raw_value_new |= self.mask
+        return int(raw_value_new)

--- a/tests/unit/test_device_settings.py
+++ b/tests/unit/test_device_settings.py
@@ -17,6 +17,24 @@ def settings(device):
     return device.settings
 
 class TestEncryptionSettings:
+    def test_adaptable_regulation(self, settings):
+        assert settings.adaptable_regulation == True
+
+    def test_vertical_instalation(self, settings):
+        assert settings.vertical_instalation == False
+
+    def test_display_flip(self, settings):
+        assert settings.display_flip == False
+
+    def test_slow_regulation(self, settings):
+        assert settings.slow_regulation == True
+
+    def test_valve_installed(self, settings):
+        assert settings.valve_installed == True
+
+    def test_lock_control(self, settings):
+        assert settings.lock_control == False
+
     def test_minimum_available_temperature(self, settings):
         assert settings.temperature_min == 6.0
 

--- a/tests/unit/test_device_settings.py
+++ b/tests/unit/test_device_settings.py
@@ -17,6 +17,12 @@ def settings(device):
     return device.settings
 
 class TestEncryptionSettings:
+    def test_minimum_available_temperature(self, settings):
+        assert settings.temperature_min == 6.0
+
+    def test_maximum_available_temperature(self, settings):
+        assert settings.temperature_max == 28.0
+
     def test_frost_protection_temperature(self, settings):
         assert settings.frost_protection_temperature == 6
 


### PR DESCRIPTION
Hi, i am working on integration bridge for home-assistant and i needed some unimplemented funkcionality.
Added features:

- Minimum available temperature GET/SET
- Maximum available temperature GET/SET
- Vertical instalation GET/SET
- Regulation speed GET/SET
- Control lock GET/SET
- Valve installed GET/SET
- Display flip GET/SET
- Adaptable regulation GET/SET

And also could you publish your library to pip so i can publish integration bridge for home-assistant? 
Thank you

Example:

from libetrv.device import eTRVDevice
mac = '00:04:2f:60:98:XX'
pin = '0000'
secret = 'e7f7efeb64426b23792a6cfcd2871fXX'

pin_bytes = bytes([int(letter) for letter in pin])
secret_bytes = bytes.fromhex(secret)
dev = eTRVDevice(mac,secret_bytes,pin_bytes)

print(dev.settings.temperature_min)
print(dev.settings.temperature_max)

q = dev.settings.configuration_bits
q.lock_control = True
q.adaptable_regulation = False
q.vertical_instalation = False
q.display_flip = False
q.slow_regulation = False
dev.settings.configuration_bits = q