### PR TITLE
Add ability for connection to fail after set number of retries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,5 +9,6 @@ setup(
     description='Monitor and control your eTRV from Python',
     author='Adam Strojek',
     author_email='adam@strojek.info',
-    packages=['libetrv', ],
+    packages=['libetrv', 'libetrv.fields'],
+    install_requires=['fire', 'bluepy', 'xxtea', 'loguru', 'cstruct']
 )


### PR DESCRIPTION
Original libetrv behavior was to retry forever in eTRVDevice.connect().

This is not good for real world applications where devices run out of battery
or go out of BLE range due to interference. This commit adds new constructor property
retry_limit for eTRVDevice that allows to throw exception to user application after set number of failures.

This PR also fixes setup.py to resolve `ModuleNotFoundError: No module named 'libetrv.fields'` error and adds basic dependencies. Now you can do `pip3 install git+https://github.com/AdamStrojek/libetrv.git`