### PR TITLE
[Fix] Invalidate eTRVDevice cached data on disconnect

### DIFF
--- a/libetrv/device.py
+++ b/libetrv/device.py
@@ -78,6 +78,9 @@ class eTRVDevice(metaclass=eTRVDeviceMeta):
             self.ble_device.disconnect()
             self.ble_device = None
             self.__pin_already_sent = False
+            for field in self.fields.values():
+                field.invalidate()
+
 
     def send_pin(self):
         if not self.__pin_already_sent:

--- a/libetrv/properties.py
+++ b/libetrv/properties.py
@@ -111,6 +111,11 @@ class eTRVData(metaclass=eTRVDataMeta):
 
         return all(results)
 
+    def invalidate(self):
+        for struct in self.raw_data.values():
+            struct.is_populated = False
+            struct.is_changed = False
+
 
 class eTRVSingleData(eTRVData):
 


### PR DESCRIPTION
On first initialization getting any `eTRVProperty` from `eTRVDevice` (battery, temperature, name, etc.) causes libetrv to connect to the thermostat and retrieve data over BLE.

However if user calls `eTRVDevice.disconnect()` subsequent reads of `eTRVProperty` values will return stale data instead of updating them over BLE. This happens because disconnect event is not propagated in any way to `eTRVData` and `eTRVData.is_populated` remains true after disconnect.

This commit adds new method `eTRVData.invalidate()` that allows `eTRVDevice.disconnect()` to propagate disconnect event further down the stack by forcing underlying data structures `is_populated` property to false. As a result subsequent read of eTRVProperties will cause BLE connection to happen and will pull fresh data from the thermostat.

@AdamStrojek Please carefully consider all side effects of setting `is_populated` to False on disconnect. I've tried to understand your data bindings model but I might be missing something. All I can say is that it works in my application with a couple thermostats over couple of days.