### PR TITLE
Strings are utf8 encoded

### DIFF
--- a/libetrv/fields/string.py
+++ b/libetrv/fields/string.py
@@ -15,7 +15,7 @@ class TextField(eTRVField):
         self.max_length = max_length
 
     def from_raw_value(self, raw_value, data):
-        return raw_value.decode('ascii').strip('\0')
+        return raw_value.decode('utf8').strip('\0')
     
     def to_raw_value(self, value, data):
-        return str.encode(value[:self.max_length]).ljust(self.max_length, b'\0')
+        return str.encode(value[:self.max_length], encoding='utf8').ljust(self.max_length, b'\0')


### PR DESCRIPTION
Trying to run 
```
python3 cli.py secret <secret> device <addr> name
```
for a device named "Køkken" results in 
```
Traceback (most recent call last):
  File "cli.py", line 80, in <module>
    fire.Fire(CLI)
  File "/home/munk/src/libetrv/venv/lib/python3.6/site-packages/fire/core.py", line 127, in Fire
    component_trace = _Fire(component, args, context, name)
  File "/home/munk/src/libetrv/venv/lib/python3.6/site-packages/fire/core.py", line 366, in _Fire
    component, remaining_args)
  File "/home/munk/src/libetrv/venv/lib/python3.6/site-packages/fire/core.py", line 542, in _CallCallable
    result = fn(*varargs, **kwargs)
  File "cli.py", line 68, in name
    device_name = self._device.name
  File "/home/munk/src/libetrv/libetrv/properties.py", line 22, in __get__
    return self.get_data_object(device).retrieve()
  File "/home/munk/src/libetrv/libetrv/properties.py", line 61, in retrieve
    return self.retrieve_object(self.device)
  File "/home/munk/src/libetrv/libetrv/properties.py", line 124, in retrieve_object
    return getattr(self, self.get_direct_field())
  File "/home/munk/src/libetrv/libetrv/fields/base.py", line 22, in __get__
    return self.from_raw_value(raw_value, data)
  File "/home/munk/src/libetrv/libetrv/fields/string.py", line 18, in from_raw_value
    return raw_value.decode('ascii').strip('\0')
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1: ordinal not in range(128)
```

As per ECO2 API documentation the device name is utf8 encoded.  Changing the encoding gives the correct result.