### PR TITLE
Update device.py

### DIFF
--- a/libetrv/device.py
+++ b/libetrv/device.py
@@ -38,7 +38,7 @@ class eTRVDevice(metaclass=eTRVDeviceMeta):
         seen = set()
         n = 0
         for i in range(int(timeout)):
-            devices = btle.Scanner().scan(1)
+            devices = btle.Scanner().scan(2)
             for d in devices:
                 if d.addr in seen:
                     continue


### PR DESCRIPTION
double timeout to also detect devices with weaker signal.

Detected eTRV devices:
00:04:2f:34:74:eb, RSSI=-71dB, key=-
00:04:2f:34:55:90, RSSI=-93dB, key=-
00:04:2f:cc:e8:87, RSSI=-94dB, key=-
00:04:2f:79:44:cf, RSSI=-67dB, key=-